### PR TITLE
getFilePath method errors for first image in a sequence

### DIFF
--- a/src/ofxImageSequence.cpp
+++ b/src/ofxImageSequence.cpp
@@ -389,7 +389,7 @@ void ofxImageSequence::setFrameRate(float rate)
 }
 
 string ofxImageSequence::getFilePath(int index){
-	if(index > 0 && index < filenames.size()){
+	if(index >= 0 && index < filenames.size()){
 		return filenames[index];
 	}
 	ofLogError("ofxImageSequence::getFilePath") << "Getting filename outside of range";


### PR DESCRIPTION
This seems to be not allowing an index of 0, while the `setFrame` method allows an index of 0 as long as it's not negative.